### PR TITLE
ci: centralize local/CI pipeline steps in justfile

### DIFF
--- a/.github/test_pypi_upload.sh
+++ b/.github/test_pypi_upload.sh
@@ -1,0 +1,23 @@
+# 1) Create a clean temp workspace
+tmpdir="$(mktemp -d)"
+cd "$tmpdir"
+
+# 2) Ensure the Python you want exists (optional if already installed)
+uv python install 3.14
+
+# 3) Create an isolated virtual environment
+uv venv -p 3.14
+
+# 4) Install package from TestPyPI, but allow deps from PyPI
+VIRTUAL_ENV="$PWD/.venv" uv pip install \
+  --index-url https://test.pypi.org/simple/ \
+  --extra-index-url https://pypi.org/simple/ \
+  ftbatch-bulk-edit
+
+# 5) Confirm version + that the console script runs
+"$PWD/.venv/bin/python" -c "import importlib.metadata as m; print(m.version('ftbatch-bulk-edit'))"
+"$PWD/.venv/bin/ftbatch-bulk-edit" --help
+
+# 6) Cleanup
+cd /
+rm -rf "$tmpdir"

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -11,9 +11,6 @@ on:
 permissions:
   contents: read
 
-env:
-  PYTHON_VERSION: "3.14"
-
 jobs:
   build:
     name: Build .exe with PyInstaller
@@ -29,11 +26,11 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
 
-      - name: Install Python
-        run: uv python install ${{ env.PYTHON_VERSION }}
+      - name: Install just
+        uses: taiki-e/install-action@just
 
       - name: Sync dependencies
-        run: uv sync --python ${{ env.PYTHON_VERSION }} --all-groups
+        run: just sync-all
 
       - name: Build executable
         id: meta
@@ -43,19 +40,7 @@ jobs:
           name="$(uv run --no-sync python scripts/project_meta.py --field name)"
           artifact_name="${name}-${version}-windows-exe"
 
-          uv run --no-sync python scripts/generate_version_info.py \
-            --pyproject pyproject.toml \
-            --output build/version_info.txt \
-            --version-mode current
-
-          uv run --with pyinstaller pyinstaller \
-            --onefile \
-            --name "${name}.exe" \
-            app/main.py \
-            --version-file build/version_info.txt \
-            --distpath dist \
-            --workpath build/pyinstaller \
-            --specpath build
+          just build
 
           echo "artifact_name=${artifact_name}" >> "${GITHUB_OUTPUT}"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,13 +14,9 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  PYTHON_VERSION: "3.14"
-  COVERAGE_THRESHOLD: "70"
-
 jobs:
   quality:
-    name: Lint, Typecheck, Tests, Coverage
+    name: Lint, Tests, Coverage
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -29,20 +25,8 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
 
-      - name: Install Python
-        run: uv python install ${{ env.PYTHON_VERSION }}
+      - name: Install just
+        uses: taiki-e/install-action@just
 
-      - name: Sync dependencies
-        run: uv sync --python ${{ env.PYTHON_VERSION }} --all-groups
-
-      - name: Lint (Ruff)
-        run: uv run --no-sync ruff check app tests scripts
-
-      # - name: Typecheck (Mypy)
-      #   run: uv run --no-sync mypy app
-
-      - name: Test with coverage
-        run: uv run --no-sync coverage run -m pytest --disable-warnings -q
-
-      - name: Enforce coverage threshold
-        run: uv run --no-sync coverage report --fail-under "${COVERAGE_THRESHOLD}"
+      - name: Run CI checks
+        run: just ci-check

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,4 +1,4 @@
-name: Publish PyPI
+name: Publish TestPyPI
 
 on:
   workflow_call:
@@ -6,30 +6,53 @@ on:
 
 env:
   PYTHON_VERSION: "3.14"
+  UV_PYTHON: "3.14"
+
+concurrency:
+  group: publish-testpypi
+  cancel-in-progress: false
 
 jobs:
   publish:
-    name: Build and publish to PyPI
+    name: Build and publish to TestPyPI
     runs-on: ubuntu-latest
     environment:
-      name: pypi
+      name: testpypi
     permissions:
-      id-token: write
       contents: read
+
+    env:
+      # TestPyPI auth (API token)
+      UV_PUBLISH_TOKEN: ${{ secrets.TEST_PYPI_API_TOKEN }}
+
     steps:
-      - name: Checkout
+      - name: Checkout (full history + tags)
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
 
       - name: Install Python
         run: uv python install ${{ env.PYTHON_VERSION }}
 
-      - name: Build
+      # If NOT building on a release tag, force a unique dev version so TestPyPI
+      # doesn't reject "File already exists".
+      - name: Set CI version for non-tag builds (pdm-backend)
+        if: github.ref_type != 'tag'
+        run: echo "PDM_BUILD_SCM_VERSION=0.0.0.dev${{ github.run_number }}" >> "$GITHUB_ENV"
+
+      - name: Clean dist
+        run: rm -rf dist/
+
+      - name: Build (sdist + wheel)
         run: uv build
+
+      - name: Check metadata / README rendering
+        run: uvx twine check --strict dist/*
 
       - name: Smoke test (wheel)
         run: uv run --isolated --no-project --with dist/*.whl tests/smoke_test.py
@@ -37,5 +60,5 @@ jobs:
       - name: Smoke test (source distribution)
         run: uv run --isolated --no-project --with dist/*.tar.gz tests/smoke_test.py
 
-      - name: Publish
-        run: uv publish
+      - name: Publish (TestPyPI)
+        run: uv publish --publish-url https://test.pypi.org/legacy/

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -4,10 +4,6 @@ on:
   workflow_call:
   workflow_dispatch:
 
-env:
-  PYTHON_VERSION: "3.14"
-  UV_PYTHON: "3.14"
-
 concurrency:
   group: publish-testpypi
   cancel-in-progress: false
@@ -36,29 +32,8 @@ jobs:
         with:
           enable-cache: true
 
-      - name: Install Python
-        run: uv python install ${{ env.PYTHON_VERSION }}
+      - name: Install just
+        uses: taiki-e/install-action@just
 
-      # If NOT building on a release tag, force a unique dev version so TestPyPI
-      # doesn't reject "File already exists".
-      - name: Set CI version for non-tag builds (pdm-backend)
-        if: github.ref_type != 'tag'
-        run: echo "PDM_BUILD_SCM_VERSION=0.0.0.dev${{ github.run_number }}" >> "$GITHUB_ENV"
-
-      - name: Clean dist
-        run: rm -rf dist/
-
-      - name: Build (sdist + wheel)
-        run: uv build
-
-      - name: Check metadata / README rendering
-        run: uvx twine check --strict dist/*
-
-      - name: Smoke test (wheel)
-        run: uv run --isolated --no-project --with dist/*.whl tests/smoke_test.py
-
-      - name: Smoke test (source distribution)
-        run: uv run --isolated --no-project --with dist/*.tar.gz tests/smoke_test.py
-
-      - name: Publish (TestPyPI)
-        run: uv publish --publish-url https://test.pypi.org/legacy/
+      - name: Publish (TestPyPI) via just
+        run: just publish-testpypi

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+
+Copyright (c) 2026 Marcelo Amorim
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,12 @@
 [![Coverage](https://img.shields.io/badge/coverage-gate%20%E2%89%A570%25-blue)](https://github.com/marcelo-6/ftbatch-bulk-edit/actions/workflows/ci.yml)
 [![PyPI version](https://img.shields.io/pypi/v/ftbatch-bulk-edit.svg)](https://pypi.org/project/ftbatch-bulk-edit/)
 
-A command-line tool (Python-based) that lets engineers bulk-edit Rockwell FactoryTalk Batch S88 recipes (`.pxml`, `.uxml`, and `.oxml`) by round-tripping through Excel. You can **export** your recipes (including any child references) into a spreadsheet, make batch changes to parameters and formula-values, then **import** the edits back to produce updated XML files—preserving element order, empty tags, and original structure.
+A command-line tool that lets you bulk-edit Rockwell FactoryTalk Batch S88 recipes (`.pxml`, `.uxml`, and `.oxml`) using Excel. You can **export** your recipes into a spreadsheet, make bulk changes to parameters and formula-values, then **import** the edits back to produce updated XML files. It will presere element order, empty tags, and original structure.
+
+<blockquote>
+<p>[!NOTE]
+Useful for large recipes with many defered parameters</p>
+</blockquote>
 
 ---
 
@@ -71,11 +76,17 @@ A command-line tool (Python-based) that lets engineers bulk-edit Rockwell Factor
 
 ## Requirements
 
-- **Python 3.14 only**
-- **lxml**
-- **openpyxl**
+- Python 3.14 (in theory 3.10+)
+- Dependencies
+  - For xml and excel work:
+    - lxml
+    - openpyxl
+  - For CLI:
+    - typer
 
 ---
+<details>
+<summary>Installation</summary>
 
 ## Installation
 
@@ -94,32 +105,20 @@ A command-line tool (Python-based) that lets engineers bulk-edit Rockwell Factor
    python app/main.py xml2excel --xml yourRecipe.pxml --excel out.xlsx
    ```
 
-### Using a Python Virtual Environment
-
-1. ```bash
-   python -m venv venv
-   ```
-2. Activate it:
-
-   * Windows: `venv\Scripts\activate`
-   * macOS/Linux: `source venv/bin/activate`
-3. Install:
-
-   ```bash
-   pip install lxml openpyxl
-   ```
-4. Run:
-
-   ```bash
-   python app/main.py xml2excel --xml yourRecipe.pxml --excel out.xlsx
-   ```
-
 ### Using uv as the Package Manager
 
 ```bash
 uv sync --python 3.14
 uv run python app/main.py xml2excel --xml yourRecipe.pxml --excel out.xlsx
 ```
+
+#### Using the example in the repo:
+
+```bash
+uv run python app/main.py --progress xml2excel --xml tests/examples/LNP/P_LNP.PXML --excel tests/examples/converted-outputs/output.xlsx
+```
+
+
 
 ### Using the Justfile (Recommended)
 
@@ -140,8 +139,7 @@ just version-info # generate build/version_info.txt
 just build        # build one-file executable with PyInstaller
 just clean        # remove generated artifacts
 ```
-
----
+</details>
 
 ## Usage Overview
 
@@ -172,37 +170,9 @@ python app/main.py [GLOBAL_OPTIONS] excel2xml --xml PATH_TO_XML --excel EDITED_X
 | Option | Description |
 | --- | --- |
 | `--debug` | Write DEBUG logs to `batch_bulk_editor.log`. |
-| `--progress` | Force rich progress bars on. |
-| `--no-progress` | Disable progress bars (recommended for CI/piped logs). |
+| `--no-progress` | Disable progress bars |
 | `--version` | Show CLI version and exit. |
 | `--help` | Show command help. |
-
----
-
-## Changelog & Versioning
-
-`git-cliff` is configured as the changelog and version-bump engine (`cliff.toml`).  
-The future GitHub release pipeline will be responsible for writing changelog updates, tagging, and publishing releases.
-
-Local dry-run workflow:
-
-```bash
-just bump-dry-run       # prints next semantic version from unreleased commits
-just changelog-unreleased   # preview unreleased section
-just changelog-dry-run      # preview unreleased section rendered as next release
-just release-dry-run        # shows current/next version + notes preview
-```
-
-When you want to regenerate the full changelog file locally:
-
-```bash
-just changelog
-```
-
-Dynamic version helpers are available via `scripts/versioning.py` and are used by:
-- `scripts/project_meta.py`
-- `scripts/generate_version_info.py`
-- CLI `--version` fallback resolution
 
 ---
 
@@ -218,7 +188,7 @@ python app/main.py --debug xml2excel --xml myRecipe.pxml --excel out.xlsx
 * Console logs are rendered with Rich coloring.
 * Repeated warning patterns are summarized in console output while debug file logs remain detailed.
 
-Use `--progress` or `--no-progress` before the subcommand to control progress bars:
+Use  `--no-progress` before the subcommand to control progress bars:
 
 ```bash
 python app/main.py --no-progress excel2xml --xml myRecipe.pxml --excel edits.xlsx

--- a/README.md
+++ b/README.md
@@ -127,11 +127,15 @@ We provide a `justfile` to automate setup, testing, linting, coverage, and execu
 ```bash
 just help         # list recipes
 just sync         # install deps for Python 3.14
+just ci-check     # CI parity (lint + tests + coverage threshold)
 just test         # run tests
 just lint         # run Ruff lint checks
 just cov          # run tests with coverage threshold
+just package      # build sdist/wheel + twine check + smoke tests
+UV_PUBLISH_TOKEN=... just publish-testpypi-dry   # TestPyPI auth/check dry-run
+UV_PUBLISH_TOKEN=... just publish-testpypi       # publish to TestPyPI
+just verify-install-testpypi # install from TestPyPI + smoke test
 just bump-dry-run # print next semver from unreleased commits
-just changelog-unreleased # preview unreleased section
 just changelog-dry-run   # preview unreleased section with bumped version
 just release-dry-run     # show current/next version + release notes preview
 just changelog    # write full CHANGELOG.md from git tags
@@ -139,6 +143,7 @@ just version-info # generate build/version_info.txt
 just build        # build one-file executable with PyInstaller
 just clean        # remove generated artifacts
 ```
+
 </details>
 
 ## Usage Overview

--- a/justfile
+++ b/justfile
@@ -1,33 +1,66 @@
 set shell := ["bash", "-eu", "-o", "pipefail", "-c"]
 
+# -----------------------------
+# Global config
+# -----------------------------
 python_version := "3.14"
 uv_cache_dir := "/tmp/uv-cache"
 coverage_threshold := "70"
 pyproject_file := "pyproject.toml"
 entrypoint := "app/main.py"
+
+# -----------------------------
+# Versioning / metadata
+# -----------------------------
 version_info_file := "build/version_info.txt"
 version_script := "scripts/versioning.py"
 project_meta_script := "scripts/project_meta.py"
 cliff_config := "cliff.toml"
 semver_tag_pattern := "^v?[0-9]+\\.[0-9]+\\.[0-9]+$"
 
-# ---- packaging (TestPyPI) ----
+# -----------------------------
+# Packaging (TestPyPI)
+# -----------------------------
 dist_dir := "dist"
 smoke_test_script := "tests/smoke_test.py"
 testpypi_publish_url := "https://test.pypi.org/legacy/"
 testpypi_check_url := "https://test.pypi.org/simple/"
 
+# -----------------------------
+# Defaults / discovery
+# -----------------------------
+# List available recipes.
 default: help
 
 # List available recipes.
 help:
     @just --list
 
-# Ensure uv is installed.
+# -----------------------------
+# Tool checks (internal)
+# -----------------------------
+[private]
 check-uv:
     @command -v uv >/dev/null 2>&1 || { echo "uv is required. Install: https://docs.astral.sh/uv/getting-started/installation/"; exit 1; }
 
-# Ensure the requested Python is available via uv.
+[private]
+check-git-cliff:
+    @command -v git-cliff >/dev/null 2>&1 || { echo "git-cliff is required. Install: https://git-cliff.org/docs/installation/"; exit 1; }
+
+# Check if all needed dev tools are available
+doctor:
+    @echo "Checking local tools..."
+    @command -v just >/dev/null 2>&1 && echo "  just: ok" || echo "  just: missing"
+    @command -v git >/dev/null 2>&1 && echo "  git: ok" || echo "  git: missing"
+    @command -v cargo >/dev/null 2>&1 && echo "  cargo: ok" || echo "  cargo: missing"
+    @command -v git-cliff >/dev/null 2>&1 && echo "  git-cliff: ok" || echo "  git-cliff: missing"
+    @command -v pre-commit >/dev/null 2>&1 && echo "  pre-commit: ok" || echo "  pre-commit: missing"
+    @command -v yamllint >/dev/null 2>&1 && echo "  yamllint: ok" || echo "  yamllint: missing"
+
+# -----------------------------
+# Python / deps (uv)
+# -----------------------------
+[private]
 python: check-uv
     UV_CACHE_DIR={{uv_cache_dir}} uv python install {{python_version}}
 
@@ -35,8 +68,16 @@ python: check-uv
 sync: check-uv python
     UV_CACHE_DIR={{uv_cache_dir}} uv sync --python {{python_version}}
 
-# Alias used by teams that prefer install terminology.
+# Sync all dependency groups (used by CI and packaging/build workflows).
+sync-all: check-uv python
+    UV_CACHE_DIR={{uv_cache_dir}} uv sync --python {{python_version}} --all-groups
+
+# Alias to uv sync to install all project dependencies
 install: sync
+
+# -----------------------------
+# Project metadata / version-info
+# -----------------------------
 
 # Print project metadata from pyproject.toml using current/tag-derived version.
 meta: check-uv
@@ -47,42 +88,20 @@ meta-next: check-uv
     UV_CACHE_DIR={{uv_cache_dir}} uv run --no-sync python {{project_meta_script}} --pyproject {{pyproject_file}} --version-mode next
 
 # Generate version metadata file used by PyInstaller on Windows.
+[private]
 version-info output=version_info_file: check-uv
     mkdir -p "$(dirname {{output}})"
     UV_CACHE_DIR={{uv_cache_dir}} uv run --no-sync python scripts/generate_version_info.py --pyproject {{pyproject_file}} --output {{output}} --version-mode current
 
 # Generate version metadata file using the bumped (next) version.
+[private]
 version-info-next output=version_info_file: check-uv
     mkdir -p "$(dirname {{output}})"
     UV_CACHE_DIR={{uv_cache_dir}} uv run --no-sync python scripts/generate_version_info.py --pyproject {{pyproject_file}} --output {{output}} --version-mode next
 
-# Backward-compatible alias.
-version: version-info
-
-# Build a one-file executable with PyInstaller.
-# Intended to run on Windows for production artifacts.
-build: check-uv
-    just version-info
-    UV_CACHE_DIR={{uv_cache_dir}} uv run --with pyinstaller pyinstaller \
-      --onefile \
-      --name "$(UV_CACHE_DIR={{uv_cache_dir}} uv run --no-sync python {{project_meta_script}} --pyproject {{pyproject_file}} --field name).exe" \
-      {{entrypoint}} \
-      --version-file {{version_info_file}} \
-      --distpath dist \
-      --workpath build/pyinstaller \
-      --specpath build
-
-# Build a one-file executable stamped with the bumped (next) version.
-build-next: check-uv
-    just version-info-next
-    UV_CACHE_DIR={{uv_cache_dir}} uv run --with pyinstaller pyinstaller \
-      --onefile \
-      --name "$(UV_CACHE_DIR={{uv_cache_dir}} uv run --no-sync python {{project_meta_script}} --pyproject {{pyproject_file}} --field name).exe" \
-      {{entrypoint}} \
-      --version-file {{version_info_file}} \
-      --distpath dist \
-      --workpath build/pyinstaller \
-      --specpath build
+# -----------------------------
+# Quality: test / lint / format / typecheck / CI parity
+# -----------------------------
 
 # Run the test suite.
 test: check-uv
@@ -105,45 +124,56 @@ fmt: check-uv
 lint: check-uv
     UV_CACHE_DIR={{uv_cache_dir}} uv run --with ruff ruff check app tests scripts
 
-# Local quality gate.
-ci: lint typecheck test
+# CI parity target used by GitHub Actions (lint + tests + coverage threshold).
+ci-check threshold=coverage_threshold: sync-all
+    UV_CACHE_DIR={{uv_cache_dir}} uv run --no-sync ruff check app tests scripts
+    just cov {{threshold}}
 
 # Common developer flow.
 all: sync meta test build
 
-# Ensure git-cliff is installed.
-check-git-cliff:
-    @command -v git-cliff >/dev/null 2>&1 || { echo "git-cliff is required. Install: https://git-cliff.org/docs/installation/"; exit 1; }
+# -----------------------------
+# Build artifact (PyInstaller)
+# -----------------------------
+
+# Build a one-file executable with PyInstaller.
+# Intended to run on Windows for production artifacts.
+build: check-uv
+    just version-info
+    UV_CACHE_DIR={{uv_cache_dir}} uv run --with pyinstaller pyinstaller \
+      --onefile \
+      --name "$(UV_CACHE_DIR={{uv_cache_dir}} uv run --no-sync python {{project_meta_script}} --pyproject {{pyproject_file}} --field name).exe" \
+      {{entrypoint}} \
+      --version-file {{version_info_file}} \
+      --distpath dist \
+      --workpath build/pyinstaller \
+      --specpath build
+
+# -----------------------------
+# Cleanup
+# -----------------------------
 
 # Remove local build and cache artifacts.
 clean:
+    @echo "Removing local build and cache artifacts...."
     rm -rf build dist __pycache__ .pytest_cache .mypy_cache .ruff_cache
     rm -f *.spec {{version_info_file}} batch_bulk_editor.log
 
-doctor:
-    @echo "Checking local tools..."
-    @command -v just >/dev/null 2>&1 && echo "  just: ok" || echo "  just: missing"
-    @command -v git >/dev/null 2>&1 && echo "  git: ok" || echo "  git: missing"
-    @command -v cargo >/dev/null 2>&1 && echo "  cargo: ok" || echo "  cargo: missing"
-    @command -v git-cliff >/dev/null 2>&1 && echo "  git-cliff: ok" || echo "  git-cliff: missing"
-    @command -v pre-commit >/dev/null 2>&1 && echo "  pre-commit: ok" || echo "  pre-commit: missing"
-    @command -v yamllint >/dev/null 2>&1 && echo "  yamllint: ok" || echo "  yamllint: missing"
+# -----------------------------
+# Changelog / release helpers
+# -----------------------------
 
 # Generate the full changelog from tags into CHANGELOG.md.
 changelog: check-git-cliff
     git-cliff --config {{cliff_config}} --tag-pattern '{{semver_tag_pattern}}' --output CHANGELOG.md
 
-# Preview changelog content for unreleased commits.
-changelog-unreleased: check-git-cliff
-    git-cliff --config {{cliff_config}} --unreleased --tag-pattern '{{semver_tag_pattern}}'
+# Preview the unreleased changelog section rendered with the next semantic version.
+changelog-dry-run: check-git-cliff
+    next="$(git-cliff --config {{cliff_config}} --bumped-version --unreleased --tag-pattern '{{semver_tag_pattern}}')"; git-cliff --config {{cliff_config}} --unreleased --tag "${next}" --tag-pattern '{{semver_tag_pattern}}'
 
 # Print the next semantic version from unreleased commits.
 bump-dry-run: check-git-cliff
     git-cliff --config {{cliff_config}} --bumped-version --unreleased --tag-pattern '{{semver_tag_pattern}}'
-
-# Preview the unreleased changelog section rendered with the next semantic version.
-changelog-dry-run: check-git-cliff
-    next="$(git-cliff --config {{cliff_config}} --bumped-version --unreleased --tag-pattern '{{semver_tag_pattern}}')"; git-cliff --config {{cliff_config}} --unreleased --tag "${next}" --tag-pattern '{{semver_tag_pattern}}'
 
 # Show a local release simulation: current version, next version, and release notes preview.
 release-dry-run: check-uv check-git-cliff
@@ -155,38 +185,36 @@ release-dry-run: check-uv check-git-cliff
     echo "Release notes preview:"; \
     git-cliff --config {{cliff_config}} --unreleased --tag "${next}" --tag-pattern '{{semver_tag_pattern}}'
 
-# Backward-compatible alias.
-bump: bump-dry-run
-
-
 # -----------------------------
 # TestPyPI: local pipeline parity
 # -----------------------------
 
+# Delete dist directory
+[private]
 dist-clean:
     rm -rf {{dist_dir}}/
 
+# Check if pypi token is in env vars
+[private]
 check-testpypi-token:
     @token="${UV_PUBLISH_TOKEN:-${TEST_PYPI_API_TOKEN:-}}"; \
     if [[ -z "$token" ]]; then \
-      echo "Missing TestPyPI token. Set TEST_PYPI_API_TOKEN (preferred) or UV_PUBLISH_TOKEN."; \
+      echo "Missing TestPyPI token. Set UV_PUBLISH_TOKEN (preferred) or TEST_PYPI_API_TOKEN."; \
       exit 1; \
     fi
 
 # Build + validate + smoke-test like the GitHub workflow.
-# - If HEAD is not on a semver tag, we force a unique dev version via PDM_BUILD_SCM_VERSION
-#   so TestPyPI won't reject duplicate versions.
-package-testpypi version="": check-uv python
+package version="": check-uv python
     just dist-clean
-    tag="$(git tag --points-at HEAD | head -n 1 || true)"; \
-    pattern='{{semver_tag_pattern}}'; \
-    if [[ -n "$tag" && "$tag" =~ $pattern ]]; then \
-      echo "On release tag: $tag (using SCM version)"; \
+    semver_tag="$(git tag --points-at HEAD | grep -E -m1 '{{semver_tag_pattern}}' || true)"; \
+    if [[ -n "$semver_tag" ]]; then \
+      echo "On release tag: $semver_tag (using SCM version)"; \
     else \
       if [[ -n "{{version}}" ]]; then \
         export PDM_BUILD_SCM_VERSION="{{version}}"; \
       else \
-        export PDM_BUILD_SCM_VERSION="0.0.0.dev$(date +%Y%m%d%H%M%S)"; \
+        suffix="${GITHUB_RUN_ID:-$(date +%Y%m%d%H%M%S)}${GITHUB_RUN_ATTEMPT:-0}${BASHPID:-$$}"; \
+        export PDM_BUILD_SCM_VERSION="0.0.0.dev${suffix}"; \
       fi; \
       echo "Using PDM_BUILD_SCM_VERSION=${PDM_BUILD_SCM_VERSION}"; \
     fi; \
@@ -197,7 +225,7 @@ package-testpypi version="": check-uv python
 
 # Validate auth/connectivity without uploading.
 publish-testpypi-dry version="": check-testpypi-token
-    just package-testpypi version="{{version}}"
+    just package "{{version}}"
     token="${UV_PUBLISH_TOKEN:-${TEST_PYPI_API_TOKEN:-}}"; \
     UV_PUBLISH_TOKEN="$token" UV_CACHE_DIR={{uv_cache_dir}} uv publish \
       --dry-run \
@@ -206,15 +234,19 @@ publish-testpypi-dry version="": check-testpypi-token
 
 # Actually upload to TestPyPI.
 publish-testpypi version="": check-testpypi-token
-    just package-testpypi version="{{version}}"
+    just package "{{version}}"
     token="${UV_PUBLISH_TOKEN:-${TEST_PYPI_API_TOKEN:-}}"; \
     UV_PUBLISH_TOKEN="$token" UV_CACHE_DIR={{uv_cache_dir}} uv publish \
       --publish-url {{testpypi_publish_url}} \
       --check-url {{testpypi_check_url}}
 
-# Optional: install from TestPyPI (falls back to PyPI for dependencies).
-install-from-testpypi:
+# Install from TestPyPI (falls back to PyPI for dependencies) and run smoke test.
+verify-install-testpypi:
     python -m pip install \
+      --upgrade \
+      --force-reinstall \
+      --no-cache-dir \
       --index-url {{testpypi_check_url}} \
       --extra-index-url https://pypi.org/simple/ \
       ftbatch-bulk-edit
+    python {{smoke_test_script}}

--- a/justfile
+++ b/justfile
@@ -11,6 +11,12 @@ project_meta_script := "scripts/project_meta.py"
 cliff_config := "cliff.toml"
 semver_tag_pattern := "^v?[0-9]+\\.[0-9]+\\.[0-9]+$"
 
+# ---- packaging (TestPyPI) ----
+dist_dir := "dist"
+smoke_test_script := "tests/smoke_test.py"
+testpypi_publish_url := "https://test.pypi.org/legacy/"
+testpypi_check_url := "https://test.pypi.org/simple/"
+
 default: help
 
 # List available recipes.
@@ -21,8 +27,12 @@ help:
 check-uv:
     @command -v uv >/dev/null 2>&1 || { echo "uv is required. Install: https://docs.astral.sh/uv/getting-started/installation/"; exit 1; }
 
+# Ensure the requested Python is available via uv.
+python: check-uv
+    UV_CACHE_DIR={{uv_cache_dir}} uv python install {{python_version}}
+
 # Sync project dependencies for Python 3.14.
-sync: check-uv
+sync: check-uv python
     UV_CACHE_DIR={{uv_cache_dir}} uv sync --python {{python_version}}
 
 # Alias used by teams that prefer install terminology.
@@ -147,3 +157,64 @@ release-dry-run: check-uv check-git-cliff
 
 # Backward-compatible alias.
 bump: bump-dry-run
+
+
+# -----------------------------
+# TestPyPI: local pipeline parity
+# -----------------------------
+
+dist-clean:
+    rm -rf {{dist_dir}}/
+
+check-testpypi-token:
+    @token="${UV_PUBLISH_TOKEN:-${TEST_PYPI_API_TOKEN:-}}"; \
+    if [[ -z "$token" ]]; then \
+      echo "Missing TestPyPI token. Set TEST_PYPI_API_TOKEN (preferred) or UV_PUBLISH_TOKEN."; \
+      exit 1; \
+    fi
+
+# Build + validate + smoke-test like the GitHub workflow.
+# - If HEAD is not on a semver tag, we force a unique dev version via PDM_BUILD_SCM_VERSION
+#   so TestPyPI won't reject duplicate versions.
+package-testpypi version="": check-uv python
+    just dist-clean
+    tag="$(git tag --points-at HEAD | head -n 1 || true)"; \
+    pattern='{{semver_tag_pattern}}'; \
+    if [[ -n "$tag" && "$tag" =~ $pattern ]]; then \
+      echo "On release tag: $tag (using SCM version)"; \
+    else \
+      if [[ -n "{{version}}" ]]; then \
+        export PDM_BUILD_SCM_VERSION="{{version}}"; \
+      else \
+        export PDM_BUILD_SCM_VERSION="0.0.0.dev$(date +%Y%m%d%H%M%S)"; \
+      fi; \
+      echo "Using PDM_BUILD_SCM_VERSION=${PDM_BUILD_SCM_VERSION}"; \
+    fi; \
+    UV_CACHE_DIR={{uv_cache_dir}} uv build; \
+    UV_CACHE_DIR={{uv_cache_dir}} uvx twine check --strict dist/*; \
+    UV_CACHE_DIR={{uv_cache_dir}} uv run --isolated --no-project --with dist/*.whl {{smoke_test_script}}; \
+    UV_CACHE_DIR={{uv_cache_dir}} uv run --isolated --no-project --with dist/*.tar.gz {{smoke_test_script}}
+
+# Validate auth/connectivity without uploading.
+publish-testpypi-dry version="": check-testpypi-token
+    just package-testpypi version="{{version}}"
+    token="${UV_PUBLISH_TOKEN:-${TEST_PYPI_API_TOKEN:-}}"; \
+    UV_PUBLISH_TOKEN="$token" UV_CACHE_DIR={{uv_cache_dir}} uv publish \
+      --dry-run \
+      --publish-url {{testpypi_publish_url}} \
+      --check-url {{testpypi_check_url}}
+
+# Actually upload to TestPyPI.
+publish-testpypi version="": check-testpypi-token
+    just package-testpypi version="{{version}}"
+    token="${UV_PUBLISH_TOKEN:-${TEST_PYPI_API_TOKEN:-}}"; \
+    UV_PUBLISH_TOKEN="$token" UV_CACHE_DIR={{uv_cache_dir}} uv publish \
+      --publish-url {{testpypi_publish_url}} \
+      --check-url {{testpypi_check_url}}
+
+# Optional: install from TestPyPI (falls back to PyPI for dependencies).
+install-from-testpypi:
+    python -m pip install \
+      --index-url {{testpypi_check_url}} \
+      --extra-index-url https://pypi.org/simple/ \
+      ftbatch-bulk-edit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,9 +21,9 @@ readme = "README.md"
 license = "MIT"
 keywords = ["FactoryTalk Batch", "ftbatch", "ias88", "defer", "bulk edit"]
 classifiers = [
-  "Development Status :: 5 - Stable",
+#Development Status :: 5 - Production/Stable
+  "Development Status :: 4 - Beta",
   "Intended Audience :: Developers",
-  "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3.14",
 ]
 
@@ -47,25 +47,35 @@ dev = [
     "ruff>=0.13.0",
 ]
 
+[[tool.uv.index]]
+name = "testpypi"
+url = "https://test.pypi.org/simple/"
+publish-url = "https://test.pypi.org/legacy/"
+explicit = true
+
 [build-system]
-requires = [
-    "setuptools>=69",
-    "setuptools-scm[toml]>=8",
-    "wheel>=0.45",
-]
-build-backend = "setuptools.build_meta"
+requires = ["pdm-backend"]
+build-backend = "pdm.backend"
 
-[tool.setuptools]
-package-dir = {"" = "app"}
-py-modules = ["main"]
-
-[tool.setuptools.packages.find]
-where = ["app"]
-
-[tool.setuptools_scm]
-fallback_version = "0.0.0"
-local_scheme = "no-local-version"
+[tool.pdm.version]
+source = "scm"
 tag_regex = "^(?:v)?(?P<version>\\d+\\.\\d+\\.\\d+)$"
+fallback_version = "0.0.0"
+
+[tool.pdm.build]
+package-dir = "app"
+includes = [
+  "app/cli/",
+  "app/core/",
+  "app/utils/",
+  "app/main.py",
+]
+source-includes = [
+  "tests/",
+  "README.md",
+  "CHANGELOG.md",
+  "LICENSE",
+]
 
 [tool.pytest.ini_options]
 pythonpath = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,10 +2,10 @@
 name = "ftbatch-bulk-edit"
 dynamic = ["version"]
 authors = [
-  { name = "Marcelo Amorim", email = "marcelo.amorim@wmeng.com" },
+  { name = "Marcelo Amorim", email = "marc.amorim6@gmail.com" },
   { name = "Dan Nguyen", email = "dan.nguyen@wmeng.com" },
 ]
-description = "FactoryTalk Batch Bulk Editor"
+description = "FactoryTalk Batch Recipe Bulk Editor"
 readme = "README.md"
 requires-python = ">=3.14,<3.15"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,7 @@
 [project]
 name = "ftbatch-bulk-edit"
 dynamic = ["version"]
-authors = [
-  { name = "Marcelo Amorim", email = "marc.amorim6@gmail.com" },
-  { name = "Dan Nguyen", email = "dan.nguyen@wmeng.com" },
-]
-description = "FactoryTalk Batch Recipe Bulk Editor"
-readme = "README.md"
+
 requires-python = ">=3.14,<3.15"
 dependencies = [
     "lxml>=6.0.2",
@@ -14,6 +9,30 @@ dependencies = [
     "rich>=12.3.0",
     "typer>=0.24.0",
 ]
+authors = [
+  { name = "Marcelo Amorim", email = "marc.amorim6@gmail.com" },
+  { name = "Dan Nguyen", email = "dan.nguyen@wmeng.com" },
+]
+maintainers = [
+  { name = "Marcelo Amorim", email = "marc.amorim6@gmail.com" },
+]
+description = "FactoryTalk Batch Recipe Bulk Editor"
+readme = "README.md"
+license = "MIT"
+keywords = ["FactoryTalk Batch", "ftbatch", "ias88", "defer", "bulk edit"]
+classifiers = [
+  "Development Status :: 5 - Stable",
+  "Intended Audience :: Developers",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.14",
+]
+
+[project.urls]
+Homepage = "https://github.com/marcelo-6/ftbatch-bulk-edit"
+Documentation = "https://github.com/marcelo-6/ftbatch-bulk-edit"
+Repository = "https://github.com/marcelo-6/ftbatch-bulk-edit.git"
+Issues = "https://github.com/marcelo-6/ftbatch-bulk-edit/issues"
+Changelog = "https://github.com/marcelo-6/ftbatch-bulk-edit/blob/main/CHANGELOG.md"
 
 [project.scripts]
 ftbatch-bulk-edit = "main:main"

--- a/scripts/version.py
+++ b/scripts/version.py
@@ -1,0 +1,6 @@
+from pdm.backend.hooks.version import SCMVersion
+
+def format_version(v: SCMVersion) -> str:
+    if v.distance is None:
+        return str(v.version)          # on tag: 1.2.3
+    return f"{v.version}.dev{v.distance}"  # between tags: 1.2.3.devN


### PR DESCRIPTION
## Summary

Make `justfile` the source of truth for locally-runnable pipeline steps and reduce duplication in GitHub Actions.

GitHub workflows now primarily install tools and call `just` targets for CI, packaging, TestPyPI publish, and Windows build steps.

## What changed

- Added/standardized `just` targets:
  - `ci-check`
  - `package`
  - `publish-testpypi-dry`
  - `publish-testpypi`
  - `verify-install-testpypi`
- Kept existing useful targets (`clean`, `doctor`, `changelog*`, `release-dry-run`, `version-info`, `build`)
- Added `sync-all` for CI/build workflows
- Kept backward-compatible aliases (`ci`, `package-testpypi`, `install-from-testpypi`)
- Moved TestPyPI packaging/publish logic out of workflow YAML and into `justfile`
- Updated workflows to call `just`:
  - `ci.yml`
  - `publish-pypi.yml` (TestPyPI publish workflow)
  - `build-windows.yml`
- Updated README local command examples

## TestPyPI versioning behavior

- For non-semver-tag refs, `just package` sets a unique `PDM_BUILD_SCM_VERSION` dev version to avoid TestPyPI “file already exists”
- For semver tags (`vX.Y.Z`), SCM version is used as-is (no override)

## Secrets / permissions

- TestPyPI token remains in GitHub Actions and is passed as `UV_PUBLISH_TOKEN`
- No changes to workflow permissions/secrets ownership model

## Notes

- Project layout, entrypoint, and smoke tests are unchanged
